### PR TITLE
Replace deprecated base url scheme HTTP by HTTPS

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var Promise = require("require-promise");
 var rimraf = require("rimraf");
 
-var poeditorBaseUrl = "http://poeditor.com/api/";
+var poeditorBaseUrl = "https://poeditor.com/api/";
 
 var poeditorApiToken;
 var poeditorProjectId;


### PR DESCRIPTION
Poeditor drops on march 13, 2020 the HTTP request support to increase security.

Received Email from Poeditor
> On March 13, 2020, we will begin dropping HTTP requests (currently allowed only for API v1), as a necessary measure to increase security with POEditor.
If you want to continue using scripts built with API v1, which will still be available after this date, please switch your HTTP requests to HTTPS.

The API v1 is also described with https https://poeditor.com/api_reference/